### PR TITLE
Use /dev/mem to read/write memory on Linux

### DIFF
--- a/source/tool/chipsec/hal/acpi.py
+++ b/source/tool/chipsec/hal/acpi.py
@@ -224,14 +224,11 @@ class ACPI:
         return rsdp
 
     #
-    # Searches for Root System Description Pointer (RSDP) in various locations for legacy/EFI systems
+    # Check RSDP in Extended BIOS Data Area
     #
-    def find_RSDP( self ):
-        rsdp_pa  = None
-        rsdp     = None
-        #
-        # Check RSDP in Extended BIOS Data Area first
-        #
+    def _find_RSDP_in_EBDA(self):
+        rsdp_pa = None
+        rsdp    = None
         if logger().HAL: logger().log( "[acpi] searching RSDP in EBDA.." )
         ebda_ptr_addr = 0x40E
         ebda_addr = struct.unpack('<H', self.cs.mem.read_physical_mem( ebda_ptr_addr, 2 ))[0] << 4
@@ -245,43 +242,54 @@ class ACPI:
                     logger().log( "[acpi] found RSDP in EBDA at: 0x%016X" % rsdp_pa )
                 else:
                     rsdp_pa = None
-        else:
-            #
-            # Search RSDP in legacy BIOS E/F segments (0xE0000 - 0xFFFFF)
-            #
-            membuf = self.cs.mem.read_physical_mem( 0xE0000, 0x20000 )
-            pos = membuf.find( ACPI_RSDP_SIG )
-            if -1 != pos:
-                rsdp_pa  = 0xE0000 + pos
-                rsdp     = self.read_RSDP(rsdp_pa)
-                if rsdp.is_RSDP_valid():
-                    logger().log( "[acpi] found RSDP in BIOS E/F segments: 0x%016X" % rsdp_pa )
-                else:
-                    rsdp_pa = None
+        return rsdp, rsdp_pa
+
+    #
+    # Search RSDP in legacy BIOS E/F segments (0xE0000 - 0xFFFFF)
+    #
+    def _find_RSDP_in_legacy_BIOS_segments(self):
+        rsdp_pa = None
+        rsdp    = None
+        membuf = self.cs.mem.read_physical_mem( 0xE0000, 0x20000 )
+        pos = membuf.find( ACPI_RSDP_SIG )
+        if -1 != pos:
+            rsdp_pa  = 0xE0000 + pos
+            rsdp     = self.read_RSDP(rsdp_pa)
+            if rsdp.is_RSDP_valid():
+                logger().log( "[acpi] found RSDP in BIOS E/F segments: 0x%016X" % rsdp_pa )
             else:
-                #
-                # Search for RSDP in the EFI memory (EFI Configuration Table)
-                #
-                if logger().HAL: logger().log( '[acpi] searching RSDP pointers in EFI Configuration Table..' )
-                (isFound,ect_pa,ect,ect_buf) = self.uefi.find_EFI_Configuration_Table()
-                if isFound:
-                    if RSDP_GUID_ACPI2_0 in ect.VendorTables:
-                        rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI2_0 ]
-                        logger().log( '[acpi] ACPI 2.0+ RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI2_0,rsdp_pa) )
-                    elif RSDP_GUID_ACPI1_0 in ect.VendorTables:
-                        rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI1_0 ]
-                        logger().log( '[acpi] ACPI 1.0 RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI1_0,rsdp_pa) )
+                rsdp_pa = None
+        return rsdp, rsdp_pa
 
-                    rsdp     = self.read_RSDP(rsdp_pa)
-                    if rsdp.is_RSDP_valid():
-                        logger().log( "[acpi] found RSDP in EFI Config Table: 0x%016X" % rsdp_pa )
-                    else:
-                        rsdp_pa = None
+    #
+    # Search for RSDP in the EFI memory (EFI Configuration Table)
+    #
+    def _find_RSDP_in_EFI_config_table(self):
+        rsdp_pa = None
+        rsdp    = None
+        if logger().HAL: logger().log( '[acpi] searching RSDP pointers in EFI Configuration Table..' )
+        (isFound,ect_pa,ect,ect_buf) = self.uefi.find_EFI_Configuration_Table()
+        if isFound:
+            if RSDP_GUID_ACPI2_0 in ect.VendorTables:
+                rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI2_0 ]
+                logger().log( '[acpi] ACPI 2.0+ RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI2_0,rsdp_pa) )
+            elif RSDP_GUID_ACPI1_0 in ect.VendorTables:
+                rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI1_0 ]
+                logger().log( '[acpi] ACPI 1.0 RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI1_0,rsdp_pa) )
 
-        if rsdp_pa is not None and rsdp is not None:
-            logger().log( rsdp ) 
-            return (rsdp_pa,rsdp)
+            rsdp     = self.read_RSDP(rsdp_pa)
+            if rsdp.is_RSDP_valid():
+                logger().log( "[acpi] found RSDP in EFI Config Table: 0x%016X" % rsdp_pa )
+            else:
+                rsdp_pa = None
+        return rsdp, rsdp_pa
 
+    #
+    # Search for RSDP in all EFI memory
+    #
+    def _find_RSDP_in_EFI(self):
+        rsdp_pa = None
+        rsdp    = None
         if logger().HAL: logger().log( "[acpi] searching all EFI memory for RSDP (this may take a minute).." )
         CHUNK_SZ = 1024*1024 # 1MB
         (smram_base, smram_limit, smram_size) = self.cs.cpu.get_SMRAM()
@@ -292,15 +300,31 @@ class ACPI:
             if -1 != pos:
                 rsdp_pa  = pa + pos
                 if logger().VERBOSE: logger().log( "[acpi] found '%s' signature at 0x%016X. Checking if valid RSDP.." % (ACPI_RSDP_SIG,rsdp_pa) )
-                rsdp_buf = self.cs.mem.read_physical_mem( rsdp_pa, ACPI_RSDP_SIZE )
-                rsdp     = RSDP(rsdp_buf) 
+                rsdp     = self.read_RSDP(rsdp_pa)
                 if rsdp.is_RSDP_valid():
                     logger().log( "[acpi] found RSDP in EFI memory: 0x%016X" % rsdp_pa )
                     break
             pa -= CHUNK_SZ
+        return rsdp, rsdp_pa
 
-        if rsdp_pa is not None: logger().log( rsdp ) 
-        return (rsdp_pa,rsdp)        
+    #
+    # Searches for Root System Description Pointer (RSDP) in various locations for legacy/EFI systems
+    #
+    def find_RSDP( self ):
+        rsdp, rsdp_pa = self._find_RSDP_in_EBDA()
+
+        if rsdp_pa is None:
+            rsdp, rsdp_pa = self._find_RSDP_in_legacy_BIOS_segments()
+
+        if rsdp_pa is None:
+            rsdp, rsdp_pa = self._find_RSDP_in_EFI_config_table()
+
+        if rsdp_pa is None:
+            rsdp, rsdp_pa = self._find_RSDP_in_EFI()
+
+        if rsdp_pa is not None: logger().log( rsdp )
+        return (rsdp_pa, rsdp)
+
     #
     # Retrieves System Description Table (RSDT or XSDT) either from RSDP or using OS API
     #

--- a/source/tool/chipsec/hal/acpi.py
+++ b/source/tool/chipsec/hal/acpi.py
@@ -214,69 +214,69 @@ class ACPI:
         self.uefi   = chipsec.hal.uefi.UEFI( self.cs )
         self.tableList = defaultdict(list)
         self.get_ACPI_table_list()
- 
+
+    def read_RSDP(self, rsdp_pa):
+        rsdp_buf = self.cs.mem.read_physical_mem( rsdp_pa, ACPI_RSDP_SIZE)
+        rsdp = RSDP(rsdp_buf)
+        if rsdp.Revision >= 0x2:
+            rsdp_buf = self.cs.mem.read_physical_mem( rsdp_pa, ACPI_RSDP_EXT_SIZE)
+            rsdp = RSDP(rsdp_buf)
+        return rsdp
+
     #
     # Searches for Root System Description Pointer (RSDP) in various locations for legacy/EFI systems
     #
     def find_RSDP( self ):
         rsdp_pa  = None
         rsdp     = None
-        rsdp_buf = None
         #
         # Check RSDP in Extended BIOS Data Area first
         #
-        if logger().HAL: logger().log( "[acpi] searching RSDP in EBDA address 0x4E0.." )
-        rsdptr_ebda = 0x40E
-        sig = self.cs.mem.read_physical_mem( rsdptr_ebda, 8 )
-        if ACPI_RSDP_SIG == sig:
-            rsdp_pa  = rsdptr_ebda
-            rsdp_buf = self.cs.mem.read_physical_mem( rsdp_pa, ACPI_RSDP_SIZE )
-            rsdp     = RSDP(rsdp_buf) 
-            if rsdp.is_RSDP_valid(): logger().log( "[acpi] found RSDP in EBDA at: 0x%016X" % rsdp_pa )
-            else: rsdp_pa = None
-        else:
-            #
-            # Search RSDP in the first 1kB of physical memory (legacy DoS area)
-            #
-            if logger().HAL: logger().log( "[acpi] searching RSDP in the first 1kB.." )
-            membuf = self.cs.mem.read_physical_mem( 0x0, 0x400 )
+        if logger().HAL: logger().log( "[acpi] searching RSDP in EBDA.." )
+        ebda_ptr_addr = 0x40E
+        ebda_addr = struct.unpack('<H', self.cs.mem.read_physical_mem( ebda_ptr_addr, 2 ))[0] << 4
+        if ebda_addr > 0x400 and ebda_addr < 0xA0000:
+            membuf = self.cs.mem.read_physical_mem(ebda_addr, 0xA0000 - ebda_addr)
             pos = membuf.find( ACPI_RSDP_SIG )
             if -1 != pos:
-                rsdp_pa  = pos
-                rsdp_buf = self.cs.mem.read_physical_mem( rsdp_pa, ACPI_RSDP_SIZE )
-                rsdp     = RSDP(rsdp_buf) 
-                if rsdp.is_RSDP_valid(): logger().log( "[acpi] found RSDP in the first 1kB: 0x%016X" % rsdp_pa )
-                else: rsdp_pa = None
+                rsdp_pa = ebda_addr + pos
+                rsdp = self.read_RSDP(rsdp_pa)
+                if rsdp.is_RSDP_valid():
+                    logger().log( "[acpi] found RSDP in EBDA at: 0x%016X" % rsdp_pa )
+                else:
+                    rsdp_pa = None
+        else:
+            #
+            # Search RSDP in legacy BIOS E/F segments (0xE0000 - 0xFFFFF)
+            #
+            membuf = self.cs.mem.read_physical_mem( 0xE0000, 0x20000 )
+            pos = membuf.find( ACPI_RSDP_SIG )
+            if -1 != pos:
+                rsdp_pa  = 0xE0000 + pos
+                rsdp     = self.read_RSDP(rsdp_pa)
+                if rsdp.is_RSDP_valid():
+                    logger().log( "[acpi] found RSDP in BIOS E/F segments: 0x%016X" % rsdp_pa )
+                else:
+                    rsdp_pa = None
             else:
                 #
-                # Search RSDP in legacy BIOS E/F segments (0xE0000 - 0xFFFFF)
+                # Search for RSDP in the EFI memory (EFI Configuration Table)
                 #
-                membuf = self.cs.mem.read_physical_mem( 0xE0000, 0x20000 )
-                pos = membuf.find( ACPI_RSDP_SIG )
-                if -1 != pos:
-                    rsdp_pa  = pos
-                    rsdp_buf = self.cs.mem.read_physical_mem( rsdp_pa, ACPI_RSDP_SIZE )
-                    rsdp     = RSDP(rsdp_buf) 
-                    if rsdp.is_RSDP_valid(): logger().log( "[acpi] found RSDP in BIOS E/F segments: 0x%016X" % rsdp_pa )
-                    else: rsdp_pa = None
-                else:
-                    #
-                    # Search for RSDP in the EFI memory (EFI Configuration Table)
-                    #
-                    if logger().HAL: logger().log( '[acpi] searching RSDP pointers in EFI Configuration Table..' )
-                    (isFound,ect_pa,ect,ect_buf) = self.uefi.find_EFI_Configuration_Table()
-                    if isFound:
-                        if RSDP_GUID_ACPI2_0 in ect.VendorTables: 
-                            rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI2_0 ]
-                            logger().log( '[acpi] ACPI 2.0+ RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI2_0,rsdp_pa) )
-                        elif RSDP_GUID_ACPI1_0 in ect.VendorTables: 
-                            rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI1_0 ]
-                            logger().log( '[acpi] ACPI 1.0 RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI1_0,rsdp_pa) )
+                if logger().HAL: logger().log( '[acpi] searching RSDP pointers in EFI Configuration Table..' )
+                (isFound,ect_pa,ect,ect_buf) = self.uefi.find_EFI_Configuration_Table()
+                if isFound:
+                    if RSDP_GUID_ACPI2_0 in ect.VendorTables:
+                        rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI2_0 ]
+                        logger().log( '[acpi] ACPI 2.0+ RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI2_0,rsdp_pa) )
+                    elif RSDP_GUID_ACPI1_0 in ect.VendorTables:
+                        rsdp_pa = ect.VendorTables[ RSDP_GUID_ACPI1_0 ]
+                        logger().log( '[acpi] ACPI 1.0 RSDP {%s} in EFI Config Table: 0x%016X' % (RSDP_GUID_ACPI1_0,rsdp_pa) )
 
-                        rsdp_buf = self.cs.mem.read_physical_mem( rsdp_pa, ACPI_RSDP_SIZE )
-                        rsdp     = RSDP(rsdp_buf) 
-                        if rsdp.is_RSDP_valid(): logger().log( "[acpi] found RSDP in EFI Config Table: 0x%016X" % rsdp_pa )
-                        else: rsdp_pa = None
+                    rsdp     = self.read_RSDP(rsdp_pa)
+                    if rsdp.is_RSDP_valid():
+                        logger().log( "[acpi] found RSDP in EFI Config Table: 0x%016X" % rsdp_pa )
+                    else:
+                        rsdp_pa = None
 
         if rsdp_pa is not None and rsdp is not None:
             logger().log( rsdp ) 

--- a/source/tool/chipsec/hal/acpi_tables.py
+++ b/source/tool/chipsec/hal/acpi_tables.py
@@ -575,8 +575,8 @@ class RSDT (ACPI_TABLE):
         self.Entries = []
 
     def parse( self, table_content ):
-        num_of_tables = len(table_content) / 8
-        self.Entries= struct.unpack( ('=%dQ' % num_of_tables), table_content )
+        num_of_tables = len(table_content) / 4
+        self.Entries= struct.unpack( ('=%dI' % num_of_tables), table_content )
         return
 
     def __str__( self ):

--- a/source/tool/chipsec/utilcmd/acpi_cmd.py
+++ b/source/tool/chipsec/utilcmd/acpi_cmd.py
@@ -28,9 +28,11 @@ Command-line utility providing access to ACPI tables
 __version__ = '1.0'
 
 import os
+import platform
 import time
 
 from chipsec.hal.acpi   import *
+from chipsec.helper.oshelper import helper
 from chipsec.command    import BaseCommand
 
 # ###################################################################
@@ -52,7 +54,7 @@ class ACPICommand(BaseCommand):
     """
 
     def requires_driver(self):
-        if len(self.argv) < 1:
+        if len(self.argv) < 1 or helper().is_linux():
             return False
         return True
 


### PR DESCRIPTION
Still not sure what to do when the `addr` is `None` in these functions:
- https://github.com/raisfathin/chipsec/blob/6ae909a4fe8fc35f1ebc9a11cf0cc55a25cc7368/source/tool/chipsec/helper/linux/helper.py#L189
- https://github.com/raisfathin/chipsec/blob/6ae909a4fe8fc35f1ebc9a11cf0cc55a25cc7368/source/tool/chipsec/helper/linux/helper.py#L203

It seems to handle when `addr` is `None` but their only caller ([1](https://github.com/raisfathin/chipsec/blob/6ae909a4fe8fc35f1ebc9a11cf0cc55a25cc7368/source/tool/chipsec/helper/linux/helper.py#L220), [2](https://github.com/raisfathin/chipsec/blob/6ae909a4fe8fc35f1ebc9a11cf0cc55a25cc7368/source/tool/chipsec/helper/linux/helper.py#L223)) don't use it.

Possible solution would be just to not use `memory_mapping` at all, or remember the last address used by either read/write operation - what do you think?  
