### PR TITLE
Forward the driver loading request to the helpers

### DIFF
--- a/source/tool/chipsec/chipset.py
+++ b/source/tool/chipsec/chipset.py
@@ -248,10 +248,10 @@ class Chipset:
         #   spi = SPI( chipsec_util._cs )
         #
 
-    def init( self, platform_code, start_svc ):
+    def init( self, platform_code, start_driver ):
 
         _unknown_platform = False
-        if start_svc: self.helper.start()
+        self.helper.start(start_driver)
 
         if platform_code is None:
             vid_did  = self.pci.read_dword( 0, 0, 0, 0 )
@@ -278,7 +278,7 @@ class Chipset:
             self.longname   = 'UnknownPlatform'
 
         self.init_cfg()
-        if _unknown_platform:
+        if _unknown_platform and start_driver:
             msg = 'Unsupported Platform: VID = 0x%04X, DID = 0x%04X' % (self.vid,self.did)
             logger().error( msg )
             raise UnknownChipsetError, msg

--- a/source/tool/chipsec/helper/efi/efihelper.py
+++ b/source/tool/chipsec/helper/efi/efihelper.py
@@ -56,6 +56,7 @@ status_dict = { 0:"EFI_SUCCESS", 1:"EFI_LOAD_ERROR", 2:"EFI_INVALID_PARAMETER", 
 class EfiHelper(Helper):
 
     def __init__(self):
+        super(EfiHelper, self).__init__()
         if sys.platform.startswith('EFI'):
             self.os_system = sys.platform
             self.os_release = "0.0"
@@ -79,11 +80,14 @@ class EfiHelper(Helper):
 # Driver/service management functions
 ###############################################################################################
 
-    def create( self ):
+    def create(self, start_driver):
         if logger().VERBOSE:
             logger().log("[helper] UEFI Helper created")
 
-    def start( self ):
+    def start(self, start_driver):
+        # The driver is part of the modified version of edk2.
+        # It is always considered as loaded.
+        self.driver_loaded = True
         if logger().VERBOSE:
             logger().log("[helper] UEFI Helper started/loaded")
 

--- a/source/tool/chipsec/helper/oshelper.py
+++ b/source/tool/chipsec/helper/oshelper.py
@@ -73,6 +73,9 @@ class Helper(object):
             else:
                 cls.registry.append((name, cls))
 
+    def __init__(self):
+        self.driver_loaded = False
+
 import chipsec.helper.helpers
 
 ## OS Helper
@@ -111,10 +114,10 @@ class OsHelper:
         except NameError:
             pass
 
-    def start( self ):
+    def start(self, start_driver):
         try:
-            self.helper.create()
-            self.helper.start()
+            self.helper.create(start_driver)
+            self.helper.start(start_driver)
         except (None,Exception) , msg:
             if logger().VERBOSE: logger().log_bad(traceback.format_exc())
             error_no = errno.ENXIO
@@ -127,6 +130,9 @@ class OsHelper:
 
     def destroy( self ):
         self.helper.delete()
+
+    def is_driver_loaded(self):
+        return self.helper.driver_loaded
 
     def is_efi( self ):
         return self.os_system.lower().startswith('efi')

--- a/source/tool/chipsec_util.py
+++ b/source/tool/chipsec_util.py
@@ -149,18 +149,18 @@ class ChipsecUtil:
             cmd = argv[ 1 ]
             if self.commands.has_key( cmd ):
                 comm = self.commands[cmd](argv, cs = _cs)
-                if comm.requires_driver():
-                    try:
-                        _cs.init( _Platform, True )
-                    except UnknownChipsetError, msg:
-                        logger().warn("*******************************************************************")
-                        logger().warn("* Unknown platform!")
-                        logger().warn("* Platform dependent functionality will likely be incorrect")
-                        logger().warn("* Error Message: \"%s\"" % str(msg))
-                        logger().warn("*******************************************************************")
-                    except (None,Exception) , msg:
-                        logger().error(str(msg))
-                        sys.exit(-1)
+
+                try:
+                    _cs.init( _Platform, comm.requires_driver())
+                except UnknownChipsetError, msg:
+                    logger().warn("*******************************************************************")
+                    logger().warn("* Unknown platform!")
+                    logger().warn("* Platform dependent functionality will likely be incorrect")
+                    logger().warn("* Error Message: \"%s\"" % str(msg))
+                    logger().warn("*******************************************************************")
+                except (None,Exception) , msg:
+                    logger().error(str(msg))
+                    sys.exit(-1)
 
                 logger().log( "[CHIPSEC] Executing command '%s' with args %s\n" % (cmd,argv[2:]) )
                 comm.run()

--- a/source/tool/tests/software/mock_helper.py
+++ b/source/tool/tests/software/mock_helper.py
@@ -14,10 +14,10 @@ class TestHelper(oshelper.Helper):
         self.os_machine = "test"
         self.driver_loaded = True
 
-    def create(self):
+    def create(self, start_driver):
         pass
 
-    def start(self):
+    def start(self, start_driver):
         pass
 
     def stop(self):


### PR DESCRIPTION
This pull request forward the request to load the driver from the util command to the helper classes. The goal is to still initialise the helper classes even if the driver not be required. Ultimately, it will give the option to use a non-driver method to perform some of the commands.

The two helper methods `start` and `create` are modified to take an extra argument (`start_driver`). The use and implementation of these is different from each platform. (These should probably be merged in a future commit, since the only calling place uses both one after the other).

The only low-level call required to initialise the driver is reading the platform VID/DID via PCI. This should  be possible via userland-only methods on both Linux and Windows. For now, a dummy value is returned '0xFFFF' which will trigger an unknown_platform resolution. The command execution will then continue normally.
